### PR TITLE
feat: update stETH-ETH aggregator

### DIFF
--- a/scripts/configs/kill-switch/kill-switch-steth-eth.json
+++ b/scripts/configs/kill-switch/kill-switch-steth-eth.json
@@ -9,7 +9,7 @@
     "trigger": {
         "type": "event",
         "filter": {
-            "address": "0x716BB759A5f6faCdfF91F0AfB613133d510e1573",
+            "address": "0xC9c8Efa84eaB332d1950e5Ba0a913b090775825c",
             "topicsInfo": [
                 {
                     "abiName": "oracleAggregator",


### PR DESCRIPTION
```
⛓️🔮 Oracle aggregators updated ⛓️🔮

Current aggregators:
WBTC_BTC aggregator: 0xD7623f1d24b35c392862fB67C9716564A117C9DE
https://etherscan.io/address/0xfdFD9C85aD200c506Cf9e21F1FD8dd01932FBB23#readContract#F2

STETH_ETH aggregator: 0xC9c8Efa84eaB332d1950e5Ba0a913b090775825c
https://etherscan.io/address/0x86392dC19c0b719886221c78AB11eb8Cf5c52812#readContract#F2

🚨🚨 Make sure that all KillSwitch Keepers are configured to monitor updated price aggregators 🚨🚨
```
Please verify that:
- `0xfdFD9C85aD200c506Cf9e21F1FD8dd01932FBB23` is a WBTC-BTC used in kill switch and it uses `0xD7623f1d24b35c392862fB67C9716564A117C9DE` as an aggregator
-  `0x86392dC19c0b719886221c78AB11eb8Cf5c52812` is a WBTC-BTC used in kill switch and it uses `0xC9c8Efa84eaB332d1950e5Ba0a913b090775825c` as an aggregator