### PR TITLE
feat: update WBTC-BTC aggregator

### DIFF
--- a/scripts/configs/kill-switch/kill-switch-wbtc-btc.json
+++ b/scripts/configs/kill-switch/kill-switch-wbtc-btc.json
@@ -9,7 +9,7 @@
     "trigger": {
         "type": "event",
         "filter": {
-            "address": "0xD7623f1d24b35c392862fB67C9716564A117C9DE",
+            "address": "0xA5e3A55cEa42B86560a5215094981c300899199D",
             "topicsInfo": [
                 {
                     "abiName": "oracleAggregator",


### PR DESCRIPTION
Similar PR to a [previous one](https://github.com/marsfoundation/spark-automations/pull/26). This time the WBTC-BTC aggregator is being updated.

```
⛓️🔮 Oracle aggregators updated ⛓️🔮

Current aggregators:
WBTC_BTC aggregator: 0xA5e3A55cEa42B86560a5215094981c300899199D
https://etherscan.io/address/0xfdFD9C85aD200c506Cf9e21F1FD8dd01932FBB23#readContract#F2

STETH_ETH aggregator: 0xC9c8Efa84eaB332d1950e5Ba0a913b090775825c
https://etherscan.io/address/0x86392dC19c0b719886221c78AB11eb8Cf5c52812#readContract#F2

🚨🚨 Make sure that all KillSwitch Keepers are configured to monitor updated price aggregators 🚨🚨
```